### PR TITLE
Quick fix to indentation

### DIFF
--- a/examples/nginx-php/docker-compose.yml
+++ b/examples/nginx-php/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - ${DOCKER_VOLUME_STORAGE:-/mnt/docker-volumes}/nginx/nginx-conf:/etc/nginx/conf.d
       - ${DOCKER_VOLUME_STORAGE:-/mnt/docker-volumes}/nginx/logs:/var/log/nginx
     links:
-        - php
+      - php
     container_name: nginx
     restart: unless-stopped
     #labels:


### PR DESCRIPTION
Just noticed while browsing, might as well clean it up right?


While I'm here, what is the purpose of `link` here? from my understanding it allows you to specify additional names to be resolved by the docker-compose network while running, the service it would communicate with is already named `php`? Or is it being used in the same way as the more commonly used `depends_on`, but in the inverse?