### PR TITLE
Adds default port mapping for homer

### DIFF
--- a/examples/homer/docker-compose.yml
+++ b/examples/homer/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     container_name: homer
     volumes:
       - ${DOCKER_VOLUME_STORAGE:-/mnt/docker-volumes}/homer:/www/assets
+    ports:
+      - "8080:8080"
     restart: unless-stopped
     environment:
       - UID=1000


### PR DESCRIPTION
Added missing port mapping, taken from [homer repository](https://github.com/bastienwirtz/homer/blob/main/docker-compose.yml)