### PR TITLE
Update docker-compose.yml deprecated env variable

### DIFF
--- a/examples/cloudflare-ddns/docker-compose.yml
+++ b/examples/cloudflare-ddns/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     security_opt:
       - no-new-privileges:true
     environment:
-      - CF_API_TOKEN=YOUR-CLOUDFLARE-API-TOKEN # pls adjust
+      - CLOUDFLARE_API_TOKEN=YOUR-CLOUDFLARE-API-TOKEN # pls adjust
       - DOMAINS=example.org,www.example.org,example.io # pls adjust; a list of fully qualified domain names separated by commas
       - PROXIED=false # if true, instructs Cloudflare to cache webpages on your machine and hide its actual IP addresses
       - TZ=Europe/Berlin


### PR DESCRIPTION
The variable CF_API_TOKEN will be deprecated in version 2.0.0 in favor of CLOUDFLARE_API_TOKEN.
Source: [https://github.com/favonia/cloudflare-ddns?tab=readme-ov-file#%EF%B8%8F-further-customization](https://github.com/favonia/cloudflare-ddns?tab=readme-ov-file#%EF%B8%8F-further-customization)