### PR TITLE
feat: add Beszel server monitoring compose example

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Tools and software for [software project management](https://en.wikipedia.org/wi
 - [Watchtower](examples/watchtower) - A container-based solution for automating Docker container base image updates.
 - [Unify Network Application](examples/unify-network-application) - The Unifi-network-application software is a powerful, enterprise wireless software engine ideal for high-density client deployments requiring low latency and high uptime performance.
 - [UpSnap](examples/upsnap) - A simple wake on lan app written with SvelteKit, Go, PocketBase and nmap.
+- [Beszel](examples/beszel) - Lightweight server monitoring platform with Docker statistics, historical data, and alerts.
 
 ### Recipe Management
 

--- a/examples/beszel/README.md
+++ b/examples/beszel/README.md
@@ -1,0 +1,15 @@
+# References
+
+- https://beszel.dev/
+- https://github.com/henrygd/beszel
+
+# Notes
+
+Beszel is a lightweight server monitoring platform that includes Docker statistics, historical data, and alert functions.
+
+The hub (this compose file) provides the web UI and communicates with agents installed on each monitored system. The agent can either be installed as a standalone binary or as a separate Docker container (see the Beszel docs for agent setup options).
+
+After starting the hub, create your admin account by visiting `http://localhost:8090` and navigating through the initial setup. Then add your systems via the dashboard and deploy the agent on each host you want to monitor.
+
+> [!NOTE]
+> Make sure the agent port (default `45876`) is reachable from the Beszel hub. For agent-only deployments on the same host, see the `extra_hosts` approach documented upstream.

--- a/examples/beszel/docker-compose.yml
+++ b/examples/beszel/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+
+  beszel:
+    image: henrygd/beszel:latest
+    container_name: beszel
+    hostname: beszel
+    restart: unless-stopped
+    ports:
+      - 8090:8090/tcp
+    expose:
+      - 8090
+    volumes:
+      - ${DOCKER_VOLUME_STORAGE:-/mnt/docker-volumes}/beszel:/beszel_data
+    #networks:
+    #  - proxy
+    #labels:
+    #  - traefik.enable=true
+    #  - traefik.docker.network=proxy
+    #  - traefik.http.routers.beszel.rule=Host(`beszel.example.com`)
+    #  - traefik.http.services.beszel.loadbalancer.server.port=8090
+    #  # Optional part for traefik middlewares
+    #  - traefik.http.routers.beszel.middlewares=local-ipwhitelist@file
+
+#networks:
+#  proxy:
+#    external: true


### PR DESCRIPTION
## Summary

Adds a Docker Compose example for [Beszel](https://beszel.dev/), a lightweight server monitoring platform that has become one of the most popular self-hosted monitoring solutions (21k+ GitHub stars).

**What's included:**
- `examples/beszel/docker-compose.yml` — Hub compose file following the existing repo conventions (`DOCKER_VOLUME_STORAGE`, Traefik labels, etc.)
- `examples/beszel/README.md` — References and usage notes
- Updated `README.md` Automation and Monitoring section with the new entry

Beszel fits naturally alongside the existing Uptime Kuma, Grafana, and Speedtest-Tracker entries in the Automation and Monitoring section.