### PR TITLE
Add Hivekeep compose example (LLM & AI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ A [proxy](https://en.wikipedia.org/wiki/Proxy_server) is a server application th
 
 A [Large Language Model (LLM)](https://en.wikipedia.org/wiki/Large_language_model) is a language model notable for its ability to achieve general-purpose language generation and other natural language processing tasks such as classification. LLMs can be used for text generation, a form of generative [AI](https://en.wikipedia.org/wiki/Artificial_intelligence), by taking an input text and repeatedly predicting the next token or word.
 
+- [Hivekeep](examples/hivekeep) - Self-hosted platform of autonomous, persistent personal AI agents that collaborate, remember, and build their own tools. Reachable via Telegram, WhatsApp, Slack, Discord, Signal and Matrix.
 - [Ollama + Open WebUI](examples/ollama-ui) - Get up and running with Llama 3, Mistral, Gemma, and other large language models using Ollama. Using an interactive, user-friendly WebUI via Open WebUI (formerly known as Ollama WebUI).
 - [Serge](examples/serge) - A web interface for chatting with Alpaca through llama.cpp. Fully dockerized, with an easy to use API.
 

--- a/examples/hivekeep/README.md
+++ b/examples/hivekeep/README.md
@@ -1,0 +1,12 @@
+# References
+
+- https://github.com/MarlBurroW/hivekeep
+- https://hivekeep.app
+
+# Notes
+
+Hivekeep is a self-hosted platform of autonomous, persistent personal AI agents. Agents collaborate, keep long-term memory, build their own tools, and are reachable via Telegram, WhatsApp, Slack, Discord, Signal and Matrix.
+
+Everything runs in a single container with Bun and SQLite. No external database or message broker is required. All state lives in the mounted data volume.
+
+After starting the container, open your browser on port 3000. The built-in setup agent (Queenie) walks you through connecting AI providers and creating your first agents. Secrets are stored in an AES-256-GCM encrypted vault.

--- a/examples/hivekeep/docker-compose.yml
+++ b/examples/hivekeep/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+
+  hivekeep:
+    image: ghcr.io/marlburrow/hivekeep:latest
+    container_name: hivekeep
+    restart: unless-stopped
+    ports:
+      - 3000:3000
+    volumes:
+      - ${DOCKER_VOLUME_STORAGE:-/mnt/docker-volumes}/hivekeep/data:/app/data
+    #networks:
+    #  - proxy
+    #labels:
+    #  - traefik.enable=true
+    #  - traefik.docker.network=proxy
+    #  - traefik.http.routers.hivekeep.rule=Host(`hivekeep.example.com`)
+    #  - traefik.http.services.hivekeep.loadbalancer.server.port=3000
+    #  # Optional part for traefik middlewares
+    #  - traefik.http.routers.hivekeep.middlewares=local-ipwhitelist@file,authelia@docker
+
+#networks:
+#  proxy:
+#    external: true


### PR DESCRIPTION
Adding a compose example for Hivekeep under LLM & AI, following the repo structure (examples/hivekeep with docker-compose.yml and README.md, traefik labels commented out like the other examples).

Hivekeep is a self-hosted, MIT-licensed platform of autonomous, persistent personal AI agents. Single container with Bun and SQLite, all state in one mounted volume, web UI on port 3000.

Links: [GitHub](https://github.com/MarlBurroW/hivekeep) | [Website](https://hivekeep.app)

Disclosure: I am the author of the project. Thanks!