### PR TITLE
Add PodFetch - self-hosted podcast manager and downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Software to manage audio and video material.
 - [Deemix](examples/deemix) - deemix is a barebone deezer downloader library built from the ashes of Deezloader Remix.
 - [Forte](examples/forte) - forte is a self-hosted music platform. You can either connect to a forte server or create your own server for your friends & family. However, it is also very convenient to use forte on your local machine as a stand-alone music player. Supports group streaming sessions.
 - [MeTube](examples/metube) - Web GUI for youtube-dl (using the yt-dlp fork) with playlist support. Allows you to download videos and audio only from YouTube and dozens of other sites.
+- [PodFetch](examples/podfetch) - Self-hosted podcast manager and downloader. Auto-downloads new episodes from RSS feeds, with a web UI and GPodder API for podcast apps.
 - [Transmission](examples/transmission) - Transmission is a fast, easy, and free BitTorrent client.
 - [FlareSolverr](examples/flaresolverr) - FlareSolverr is a proxy server to bypass Cloudflare and DDoS-GUARD protection.
 - [Plex](examples/plex) - Plex organizes video, music and photos from personal media libraries and streams them to smart TVs, streaming boxes and mobile devices.

--- a/examples/podfetch/README.md
+++ b/examples/podfetch/README.md
@@ -1,0 +1,4 @@
+# References
+- https://github.com/SamTV12345/PodFetch
+# Notes
+Self-hosted podcast manager and downloader. GPodder API compatible (syncs with AntennaPod and similar apps). Web UI for browsing and playing episodes, OPML import/export, iTunes and Podcast Index search. Uses SQLite by default, Postgres also supported via separate compose file. First start has no auth — enable BASIC_AUTH in environment to require login.

--- a/examples/podfetch/docker-compose.yml
+++ b/examples/podfetch/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+
+  podfetch:
+    image: samuel19982/podfetch:latest
+    container_name: podfetch
+    hostname: podfetch
+    restart: unless-stopped
+    ports:
+      - "8000:8000" # web ui
+    expose:
+      - 8000
+    volumes:
+      - ${DOCKER_VOLUME_STORAGE:-/mnt/docker-volumes}/podfetch/podcasts:/app/podcasts
+      - ${DOCKER_VOLUME_STORAGE:-/mnt/docker-volumes}/podfetch/db:/app/db
+    environment:
+      - POLLING_INTERVAL=60
+      - DATABASE_URL=sqlite:///app/db/podcast.db
+    #networks:
+    #  - proxy
+    #labels:
+    #  - traefik.enable=true
+    #  - traefik.http.routers.podfetch.rule=Host(`podfetch.example.com`)
+    #  - traefik.http.services.podfetch.loadbalancer.server.port=8000
+    #  - traefik.docker.network=proxy
+    #  # Part for optional traefik middlewares
+    #  - traefik.http.routers.podfetch.middlewares=local-ipwhitelist@file,basic-auth@file
+
+#networks:
+#  proxy:
+#    external: true


### PR DESCRIPTION
Adds PodFetch (https://github.com/SamTV12345/PodFetch), a self-hosted podcast manager and downloader with GPodder API compatibility and web UI.

- Rust backend, React/TS frontend
- SQLite by default, Postgres optional
- Multi-arch Docker image (amd64+arm64)